### PR TITLE
プロジェクトのスキーマ設定

### DIFF
--- a/Config/Debug-Stub.xcconfig
+++ b/Config/Debug-Stub.xcconfig
@@ -1,0 +1,6 @@
+OTHER_SWIFT_FLAGS = "-D" "DEBUG" "-D" "STUB" -Xfrontend -warn-long-function-bodies=1000
+CODE_SIGN_IDENTITY = iPhone Developer
+CODE_SIGN_STYLE = Manual
+DEVELOPMENT_TEAM = WLN29ZWFG6
+PROVISIONING_PROFILE_SPECIFIER = match Development *
+PRODUCT_BUNDLE_IDENTIFIER = tech.watanave.HiraganaTranslator.stub

--- a/Config/Debug.xcconfig
+++ b/Config/Debug.xcconfig
@@ -1,0 +1,6 @@
+OTHER_SWIFT_FLAGS = "-D" "DEBUG" -Xfrontend -warn-long-function-bodies=1000
+CODE_SIGN_IDENTITY = iPhone Developer
+CODE_SIGN_STYLE = Manual
+DEVELOPMENT_TEAM = WLN29ZWFG6
+PROVISIONING_PROFILE_SPECIFIER = match Development *
+PRODUCT_BUNDLE_IDENTIFIER = tech.watanave.HiraganaTranslator

--- a/Config/Release.xcconfig
+++ b/Config/Release.xcconfig
@@ -1,0 +1,5 @@
+CODE_SIGN_IDENTITY = iPhone Distribution
+CODE_SIGN_STYLE = Manual
+DEVELOPMENT_TEAM = WLN29ZWFG6
+PROVISIONING_PROFILE_SPECIFIER = match AdHoc tech.watanave.HiraganaTranslator
+PRODUCT_BUNDLE_IDENTIFIER = tech.watanave.HiraganaTranslator

--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		08A9AC2923D5EF5C00C3DAE5 /* SwinjectAutoregistration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwinjectAutoregistration.framework; path = Carthage/Build/iOS/SwinjectAutoregistration.framework; sourceTree = "<group>"; };
 		08A9AC2A23D5EF5C00C3DAE5 /* RxOptional.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxOptional.framework; path = Carthage/Build/iOS/RxOptional.framework; sourceTree = "<group>"; };
 		08A9AC4E23D5F59000C3DAE5 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
+		08A9AC5523D600A200C3DAE5 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		08A9AC5623D600B900C3DAE5 /* Debug-Stub.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Debug-Stub.xcconfig"; sourceTree = "<group>"; };
+		08A9AC5723D600C500C3DAE5 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		1A0406D1DAEA05C3697F5761 /* Pods-HiraganaTranslator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslator.debug.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslator/Pods-HiraganaTranslator.debug.xcconfig"; sourceTree = "<group>"; };
 		1A9EB700DB6250E3F07B3D31 /* Pods_HiraganaTranslator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HiraganaTranslator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B7B19D23C14E2126A848D45 /* Pods-HiraganaTranslatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslatorTests.release.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslatorTests/Pods-HiraganaTranslatorTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -104,6 +107,7 @@
 				08988C7923D5E27600BAA135 /* HiraganaTranslator */,
 				08988C9023D5E27A00BAA135 /* HiraganaTranslatorTests */,
 				08988C7823D5E27600BAA135 /* Products */,
+				08A9AC5423D6008200C3DAE5 /* Config */,
 				DEB8C712E248728D8F9595A1 /* Pods */,
 				A0A8EF0F5FA4BC37D28C5F49 /* Frameworks */,
 			);
@@ -148,6 +152,16 @@
 				08A9AC4E23D5F59000C3DAE5 /* R.generated.swift */,
 			);
 			path = generated;
+			sourceTree = "<group>";
+		};
+		08A9AC5423D6008200C3DAE5 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				08A9AC5523D600A200C3DAE5 /* Debug.xcconfig */,
+				08A9AC5623D600B900C3DAE5 /* Debug-Stub.xcconfig */,
+				08A9AC5723D600C500C3DAE5 /* Release.xcconfig */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		A0A8EF0F5FA4BC37D28C5F49 /* Frameworks */ = {
@@ -474,6 +488,7 @@
 /* Begin XCBuildConfiguration section */
 		08988C9423D5E27A00BAA135 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 08A9AC5523D600A200C3DAE5 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -534,6 +549,7 @@
 		};
 		08988C9523D5E27A00BAA135 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 08A9AC5723D600C500C3DAE5 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -591,7 +607,6 @@
 			baseConfigurationReference = 1A0406D1DAEA05C3697F5761 /* Pods-HiraganaTranslator.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WLN29ZWFG6;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -614,8 +629,6 @@
 			baseConfigurationReference = 06B0DB1E939CAFA15A0C11F0 /* Pods-HiraganaTranslator.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WLN29ZWFG6;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -678,6 +691,112 @@
 			};
 			name = Release;
 		};
+		08A9AC5123D6007200C3DAE5 /* Debug-Stub */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 08A9AC5623D600B900C3DAE5 /* Debug-Stub.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = "Debug-Stub";
+		};
+		08A9AC5223D6007200C3DAE5 /* Debug-Stub */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1A0406D1DAEA05C3697F5761 /* Pods-HiraganaTranslator.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = WLN29ZWFG6;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = HiraganaTranslator/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = tech.watanave.HiraganaTranslator;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug-Stub";
+		};
+		08A9AC5323D6007200C3DAE5 /* Debug-Stub */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F6D9B96279B959B8F0300CE5 /* Pods-HiraganaTranslatorTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WLN29ZWFG6;
+				INFOPLIST_FILE = HiraganaTranslatorTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = tech.watanave.HiraganaTranslatorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HiraganaTranslator.app/HiraganaTranslator";
+			};
+			name = "Debug-Stub";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -685,6 +804,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				08988C9423D5E27A00BAA135 /* Debug */,
+				08A9AC5123D6007200C3DAE5 /* Debug-Stub */,
 				08988C9523D5E27A00BAA135 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -694,6 +814,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				08988C9723D5E27A00BAA135 /* Debug */,
+				08A9AC5223D6007200C3DAE5 /* Debug-Stub */,
 				08988C9823D5E27A00BAA135 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -703,6 +824,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				08988C9A23D5E27A00BAA135 /* Debug */,
+				08A9AC5323D6007200C3DAE5 /* Debug-Stub */,
 				08988C9B23D5E27A00BAA135 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/HiraganaTranslator.xcodeproj/xcshareddata/xcschemes/HiraganaTranslator-Stub.xcscheme
+++ b/HiraganaTranslator.xcodeproj/xcshareddata/xcschemes/HiraganaTranslator-Stub.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08988C7623D5E27600BAA135"
+               BuildableName = "HiraganaTranslator.app"
+               BlueprintName = "HiraganaTranslator"
+               ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08988C8C23D5E27A00BAA135"
+               BuildableName = "HiraganaTranslatorTests.xctest"
+               BlueprintName = "HiraganaTranslatorTests"
+               ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "08988C7623D5E27600BAA135"
+            BuildableName = "HiraganaTranslator.app"
+            BlueprintName = "HiraganaTranslator"
+            ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "08988C7623D5E27600BAA135"
+            BuildableName = "HiraganaTranslator.app"
+            BlueprintName = "HiraganaTranslator"
+            ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HiraganaTranslator.xcodeproj/xcshareddata/xcschemes/HiraganaTranslator.xcscheme
+++ b/HiraganaTranslator.xcodeproj/xcshareddata/xcschemes/HiraganaTranslator.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08988C7623D5E27600BAA135"
+               BuildableName = "HiraganaTranslator.app"
+               BlueprintName = "HiraganaTranslator"
+               ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08988C8C23D5E27A00BAA135"
+               BuildableName = "HiraganaTranslatorTests.xctest"
+               BlueprintName = "HiraganaTranslatorTests"
+               ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "08988C7623D5E27600BAA135"
+            BuildableName = "HiraganaTranslator.app"
+            BlueprintName = "HiraganaTranslator"
+            ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "08988C7623D5E27600BAA135"
+            BuildableName = "HiraganaTranslator.app"
+            BlueprintName = "HiraganaTranslator"
+            ReferencedContainer = "container:HiraganaTranslator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
開発用にAPIを叩かずに固定値を返すスタブモードを用意します。
スタブモード用のSchemeを定義しました。

また、XcodeのBuildSettingをxcconfigファイル経由で書き換えるようにプロジェクトを変更しています。