### PR TITLE
Swiftlint / Cocoapods ワーニングの解消

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,106 +1,19 @@
 included:
   - HiraganaTranslator
 excluded:
-  - HiraganaTranslator/generated/
-  - Tests/
-analyzer_rules:
-  - unused_declaration
-  - unused_import
-opt_in_rules:
-  - anyobject_protocol
-  - array_init
-  - attributes
-  - closure_end_indentation
-  - closure_spacing
-  - collection_alignment
-  - contains_over_filter_count
-  - contains_over_filter_is_empty
-  - contains_over_first_not_nil
-  - discouraged_object_literal
-  - empty_count
-  - empty_string
-  - empty_xctest_method
-  - explicit_init
-  - extension_access_modifier
-  - fallthrough
-  - fatal_error_message
-  # - file_header
-  - file_name
-  - first_where
-  - flatmap_over_map_reduce
-  - identical_operands
-  - joined_default_parameter
-  - legacy_random
-  - let_var_whitespace
-  - last_where
-  - literal_expression_end_indentation
-  - lower_acl_than_parent
-  - modifier_order
-  - nimble_operator
-  - nslocalizedstring_key
-  - number_separator
-  - object_literal
-  - operator_usage_whitespace
-  - overridden_super_call
-  - override_in_extension
-  - pattern_matching_keywords
-  - private_action
-  - private_outlet
-  - prohibited_interface_builder
-  - prohibited_super_call
-  - quick_discouraged_call
-  - quick_discouraged_focused_test
-  - quick_discouraged_pending_test
-  - reduce_into
-  - redundant_nil_coalescing
-  - redundant_type_annotation
-  - single_test_class
-  - sorted_first_last
-  - sorted_imports
-  - static_operator
-  - strong_iboutlet
-  - toggle_bool
-  - unavailable_function
-  - unneeded_parentheses_in_closure_argument
-  - unowned_variable_capture
-  - untyped_error_in_catch
-  - vertical_parameter_alignment_on_call
-  # - vertical_whitespace_closing_braces
-  # - vertical_whitespace_opening_braces
-  - xct_specific_matcher
-  - yoda_condition
+  - HiraganaTranslator/generated
+  - HiraganaTranslatorTests
+  - Pods
+  - Carthage
+  - vendor
+
+disabled_rules:
+  - line_length
+  - trailing_whitespace
+  - statement_position
+  - force_cast
 
 identifier_name:
-  excluded:
-    - id
-number_separator:
-  minimum_length: 5
-file_name:
-  excluded:
-    - main.swift
-    - LinuxMain.swift
-    - TestHelpers.swift
-    - shim.swift
-    - AutomaticRuleTests.generated.swift
-
-custom_rules:
-  rule_id:
-    included: Source/SwiftLintFramework/Rules/.+/\w+\.swift
-    name: Rule ID
-    message: Rule IDs must be all lowercase, snake case and not end with `rule`
-    regex: identifier:\s*("\w+_rule"|"\S*[^a-z_]\S*")
-    severity: error
-  fatal_error:
-    name: Fatal Error
-    excluded: "Tests/*"
-    message: Prefer using `queuedFatalError` over `fatalError` to avoid leaking compiler host machine paths.
-    regex: \bfatalError\b
-    match_kinds:
-      - identifier
-    severity: error
-  rule_test_function:
-    included: Tests/SwiftLintFrameworkTests/RulesTests.swift
-    name: Rule Test Function
-    message: Rule Test Function mustn't end with `rule`
-    regex: func\s*test\w+(r|R)ule\(\)
-    severity: error
+    excluded:
+      - id
+      - ok

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,7 +24,7 @@ opt_in_rules:
   - extension_access_modifier
   - fallthrough
   - fatal_error_message
-  - file_header
+  # - file_header
   - file_name
   - first_where
   - flatmap_over_map_reduce
@@ -65,8 +65,8 @@ opt_in_rules:
   - unowned_variable_capture
   - untyped_error_in_catch
   - vertical_parameter_alignment_on_call
-  - vertical_whitespace_closing_braces
-  - vertical_whitespace_opening_braces
+  # - vertical_whitespace_closing_braces
+  # - vertical_whitespace_opening_braces
   - xct_specific_matcher
   - yoda_condition
 

--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -653,7 +653,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F6D9B96279B959B8F0300CE5 /* Pods-HiraganaTranslatorTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WLN29ZWFG6;
@@ -676,7 +675,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4B7B19D23C14E2126A848D45 /* Pods-HiraganaTranslatorTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WLN29ZWFG6;
@@ -782,7 +780,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5FEC31C01376C2DD0DFFAB83 /* Pods-HiraganaTranslatorTests.debug-stub.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WLN29ZWFG6;

--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -655,7 +655,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WLN29ZWFG6;
 				INFOPLIST_FILE = HiraganaTranslatorTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -677,7 +676,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WLN29ZWFG6;
 				INFOPLIST_FILE = HiraganaTranslatorTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -782,7 +780,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WLN29ZWFG6;
 				INFOPLIST_FILE = HiraganaTranslatorTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		1A0406D1DAEA05C3697F5761 /* Pods-HiraganaTranslator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslator.debug.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslator/Pods-HiraganaTranslator.debug.xcconfig"; sourceTree = "<group>"; };
 		1A9EB700DB6250E3F07B3D31 /* Pods_HiraganaTranslator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HiraganaTranslator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B7B19D23C14E2126A848D45 /* Pods-HiraganaTranslatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslatorTests.release.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslatorTests/Pods-HiraganaTranslatorTests.release.xcconfig"; sourceTree = "<group>"; };
+		566DC8C0485EE8977C217298 /* Pods-HiraganaTranslator.debug-stub.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslator.debug-stub.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslator/Pods-HiraganaTranslator.debug-stub.xcconfig"; sourceTree = "<group>"; };
+		5FEC31C01376C2DD0DFFAB83 /* Pods-HiraganaTranslatorTests.debug-stub.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslatorTests.debug-stub.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslatorTests/Pods-HiraganaTranslatorTests.debug-stub.xcconfig"; sourceTree = "<group>"; };
 		EECED8D85EEFBB8E17B46E22 /* Pods_HiraganaTranslatorTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HiraganaTranslatorTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6D9B96279B959B8F0300CE5 /* Pods-HiraganaTranslatorTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HiraganaTranslatorTests.debug.xcconfig"; path = "Target Support Files/Pods-HiraganaTranslatorTests/Pods-HiraganaTranslatorTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -190,6 +192,8 @@
 				06B0DB1E939CAFA15A0C11F0 /* Pods-HiraganaTranslator.release.xcconfig */,
 				F6D9B96279B959B8F0300CE5 /* Pods-HiraganaTranslatorTests.debug.xcconfig */,
 				4B7B19D23C14E2126A848D45 /* Pods-HiraganaTranslatorTests.release.xcconfig */,
+				566DC8C0485EE8977C217298 /* Pods-HiraganaTranslator.debug-stub.xcconfig */,
+				5FEC31C01376C2DD0DFFAB83 /* Pods-HiraganaTranslatorTests.debug-stub.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -754,7 +758,7 @@
 		};
 		08A9AC5223D6007200C3DAE5 /* Debug-Stub */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1A0406D1DAEA05C3697F5761 /* Pods-HiraganaTranslator.debug.xcconfig */;
+			baseConfigurationReference = 566DC8C0485EE8977C217298 /* Pods-HiraganaTranslator.debug-stub.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = WLN29ZWFG6;
@@ -776,7 +780,7 @@
 		};
 		08A9AC5323D6007200C3DAE5 /* Debug-Stub */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F6D9B96279B959B8F0300CE5 /* Pods-HiraganaTranslatorTests.debug.xcconfig */;
+			baseConfigurationReference = 5FEC31C01376C2DD0DFFAB83 /* Pods-HiraganaTranslatorTests.debug-stub.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";

--- a/HiraganaTranslator/AppDelegate.swift
+++ b/HiraganaTranslator/AppDelegate.swift
@@ -11,27 +11,23 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_ application: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
 }
-

--- a/HiraganaTranslator/AppDelegate.swift
+++ b/HiraganaTranslator/AppDelegate.swift
@@ -11,17 +11,14 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    func application(_ application: UIApplication,
-                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication,
-                     configurationForConnecting connectingSceneSession: UISceneSession,
-                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)

--- a/HiraganaTranslator/SceneDelegate.swift
+++ b/HiraganaTranslator/SceneDelegate.swift
@@ -12,9 +12,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-    func scene(_ scene: UIScene,
-               willConnectTo session: UISceneSession,
-               options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        if !(scene is UIWindowScene) {
+            return
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/HiraganaTranslator/SceneDelegate.swift
+++ b/HiraganaTranslator/SceneDelegate.swift
@@ -12,42 +12,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/HiraganaTranslator/ViewController.swift
+++ b/HiraganaTranslator/ViewController.swift
@@ -15,6 +15,4 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
-
 }
-


### PR DESCRIPTION
# Swlintlint
デフォルトテンプレートのlintルールを適用したところ、大量にワーニングが発生したので  
いつも利用しているlintルールに変更しました。

# Cocoapods
`pod install` 時に発生するワーニングを解消しました。

# その他
ビルド設定に不要なものが含まれていたので削除しました。  
→ `DEVELOPMENT_TEAM`  (これはconfigファイルで設定する)