### PR TITLE
NavigationControllerを導入

### DIFF
--- a/HiraganaTranslator/view/SceneDelegate.swift
+++ b/HiraganaTranslator/view/SceneDelegate.swift
@@ -18,7 +18,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         let window = UIWindow(windowScene: windowScene)
         self.window = window
-        window.rootViewController = sharedMenuContainer.resolve(MenuViewController.self)!
+        let viewController = sharedMenuContainer.resolve(MenuViewController.self)!
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.setNavigationBarHidden(true, animated: false)
+        window.rootViewController = navigationController
         window.makeKeyAndVisible()
     }
 

--- a/HiraganaTranslator/view/menu/MenuViewController.swift
+++ b/HiraganaTranslator/view/menu/MenuViewController.swift
@@ -92,7 +92,7 @@ class MenuViewController: UIViewController {
                     break // TODO: 画面遷移を実装する
                 case .textInput:
                     let viewController = sharedTextInputContainer.resolve(TextInputViewController.self)!
-                    self.present(viewController, animated: true, completion: nil)
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 }
             }
             .disposed(by: self.disposeBag)

--- a/HiraganaTranslator/view/textInput/TextInputViewController.swift
+++ b/HiraganaTranslator/view/textInput/TextInputViewController.swift
@@ -35,8 +35,6 @@ class TextInputViewController: UIViewController {
         self.alertService = alertService
         
         super.init(nibName: nil, bundle: nil)
-        self.modalPresentationStyle = .fullScreen
-        self.modalTransitionStyle = .flipHorizontal
     }
 
     override func viewDidLoad() {

--- a/HiraganaTranslator/view/textInput/TextInputViewController.swift
+++ b/HiraganaTranslator/view/textInput/TextInputViewController.swift
@@ -88,9 +88,9 @@ class TextInputViewController: UIViewController {
                 switch transition {
                 case .translateResult:
                     let viewController = sharedTranslateResultContainer.resolve(TranslateResultViewController.self)!
-                    self.present(viewController, animated: true, completion: nil)
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 case .dismiss:
-                    self.dismiss(animated: true, completion: nil)
+                    self.navigationController?.popViewController(animated: true)
                 case .errorAlert(let errorMessage):
                     self.alertService.present(viewController: self,
                                               message: errorMessage,

--- a/HiraganaTranslator/view/translateResult/TranslateResultViewController.swift
+++ b/HiraganaTranslator/view/translateResult/TranslateResultViewController.swift
@@ -35,8 +35,6 @@ class TranslateResultViewController: UIViewController {
         self.alertService = alertService
             
         super.init(nibName: nil, bundle: nil)
-        self.modalPresentationStyle = .fullScreen
-        self.modalTransitionStyle = .flipHorizontal
     }
 
     override func viewDidLoad() {

--- a/HiraganaTranslator/view/translateResult/TranslateResultViewController.swift
+++ b/HiraganaTranslator/view/translateResult/TranslateResultViewController.swift
@@ -87,14 +87,9 @@ class TranslateResultViewController: UIViewController {
                 guard let self = self else { return }
                 switch transition {
                 case .menu:
-                    // FIXME: NavigationControllerを利用した実装に置き換える
-                    guard var viewController = self.presentingViewController else { return }
-                    while viewController.presentingViewController != nil {
-                        viewController = viewController.presentingViewController!
-                    }
-                    viewController.dismiss(animated: true, completion: nil)
+                    self.navigationController?.popToRootViewController(animated: true)
                 case .dismiss:
-                    self.dismiss(animated: true, completion: nil)
+                    self.navigationController?.popViewController(animated: true)
                 case .errorAlert(let errorMessage):
                     self.alertService.present(viewController: self,
                                               message: errorMessage,


### PR DESCRIPTION
変換結果画面からメニュー画面へ戻る際、Modalを2つ同時に閉じる必要があります。
そもそも、Modalが2重になっているのも気持ちが悪い。。。
そこで、NavigationControllerを導入することにしました。
NavigationBarは非表示とし、画面の見た目に変化はありません。