### PR TITLE
テストターゲットでのビルドエラーを解消

### DIFF
--- a/HiraganaTranslatorTests/view/textIput/TextInputViewControllerTests.swift
+++ b/HiraganaTranslatorTests/view/textIput/TextInputViewControllerTests.swift
@@ -104,10 +104,10 @@ class TextInputViewControllerTests: FBSnapshotTestCase {
 
         
         let result = TranslateResult(
-            words: [Word(surface: "漢字",
-                         furigana: "かんじ")],
             surfaceWordIndexes: [0, 0],
             furiganaWordIndexes: [1, 1],
+            surfaceWordInitialIndexes: [0],
+            furiganaWordInitialIndexes: [0],
             surfaceCentence: "漢字",
             furiganaCentence: "かんじ")
         var state = self.viewModel.initialState

--- a/HiraganaTranslatorTests/view/textIput/TextInputViewModelTests.swift
+++ b/HiraganaTranslatorTests/view/textIput/TextInputViewModelTests.swift
@@ -50,7 +50,12 @@ class TextInputViewModelTests: XCTestCase {
             .next(0, .uninitialized),
             .next(0, .loading),
             .next(0, .success(TranslateResult(
-                words: [word], surfaceWordIndexes: [], furiganaWordIndexes: [], surfaceCentence: "", furiganaCentence: "")))]
+                surfaceWordIndexes: [],
+                furiganaWordIndexes: [],
+                surfaceWordInitialIndexes: [0],
+                furiganaWordInitialIndexes: [0],
+                surfaceCentence: "",
+                furiganaCentence: "")))]
         )
         
         verify(self.translateApi, atLeastOnce()).translate(sentence: "")


### PR DESCRIPTION
`TranslateResult` の型を試行錯誤している間にテストでビルドエラーが起こっていた。。