### PR TITLE
Error型からユーザーに表示する文字列に変換するクラスを実装

### DIFF
--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		084876CD23DB79E9005302D1 /* PasteBoardModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084876CC23DB79E9005302D1 /* PasteBoardModelTests.swift */; };
 		084876D523DB8680005302D1 /* MenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084876D423DB8680005302D1 /* MenuViewModelTests.swift */; };
 		08655AAD23DC13B1000E378E /* ErrorTranslatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08655AAC23DC13B1000E378E /* ErrorTranslatorTests.swift */; };
+		08655AAF23DC181F000E378E /* ErrorTranslatorMock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08655AAE23DC181F000E378E /* ErrorTranslatorMock.generated.swift */; };
 		0869AB9A23DBA8DD00156A52 /* TranslateApiMock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0869AB9923DBA8DC00156A52 /* TranslateApiMock.generated.swift */; };
 		0869AB9C23DBABF100156A52 /* TextInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0869AB9B23DBABF100156A52 /* TextInputViewModelTests.swift */; };
 		08988C7B23D5E27600BAA135 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08988C7A23D5E27600BAA135 /* AppDelegate.swift */; };
@@ -127,6 +128,7 @@
 		084876CC23DB79E9005302D1 /* PasteBoardModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteBoardModelTests.swift; sourceTree = "<group>"; };
 		084876D423DB8680005302D1 /* MenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModelTests.swift; sourceTree = "<group>"; };
 		08655AAC23DC13B1000E378E /* ErrorTranslatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTranslatorTests.swift; sourceTree = "<group>"; };
+		08655AAE23DC181F000E378E /* ErrorTranslatorMock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTranslatorMock.generated.swift; sourceTree = "<group>"; };
 		0869AB9923DBA8DC00156A52 /* TranslateApiMock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranslateApiMock.generated.swift; sourceTree = "<group>"; };
 		0869AB9B23DBABF100156A52 /* TextInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputViewModelTests.swift; sourceTree = "<group>"; };
 		08988C7723D5E27600BAA135 /* HiraganaTranslator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HiraganaTranslator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -498,6 +500,7 @@
 				08A7D6F423DB9DA90073A85F /* ViewModelMocks.generated.swift */,
 				083DAE3E23DBB6C1008F9BC2 /* ModelMocks.generated.swift */,
 				0869AB9923DBA8DC00156A52 /* TranslateApiMock.generated.swift */,
+				08655AAE23DC181F000E378E /* ErrorTranslatorMock.generated.swift */,
 			);
 			path = generated;
 			sourceTree = "<group>";
@@ -826,10 +829,11 @@
 				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ViewModelMocks.generated.swift",
 				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/PasteBoardModelMock.generated.swift",
 				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/TextRecognizeModelMock.generated.swift",
+				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ErrorTranslatorMock.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# generate mock for ViewModel\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \\\n    \"$PROJECT_NAME\" mocking \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ViewModelMocks.generated.swift\" \\\n    $(find $PROJECT_DIR/$PROJECT_NAME/view/ -name *ViewModel.swift -print0 | xargs -0)\n\n# generate mock for Models\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \"$PROJECT_NAME\" \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ModelMocks.generated.swift\" \\\n    $(find $PROJECT_DIR/$PROJECT_NAME/model/ -name *Model.swift -print0 | xargs -0)\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \"$PROJECT_NAME\" \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/TranslateApiMock.generated.swift\" \\\n    $PROJECT_DIR/$PROJECT_NAME/model/TranslateApi.swift\n";
+			shellScript = "# generate mock for ViewModel\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \\\n    \"$PROJECT_NAME\" mocking \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ViewModelMocks.generated.swift\" \\\n    $(find $PROJECT_DIR/$PROJECT_NAME/view/ -name *ViewModel.swift -print0 | xargs -0)\n\n# generate mock for Models\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \"$PROJECT_NAME\" \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ModelMocks.generated.swift\" \\\n    $(find $PROJECT_DIR/$PROJECT_NAME/model/ -name *Model.swift -print0 | xargs -0)\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \"$PROJECT_NAME\" \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/TranslateApiMock.generated.swift\" \\\n    $PROJECT_DIR/$PROJECT_NAME/model/TranslateApi.swift\n\n# generate mock for ErrorTranslator\nCarthage/Checkouts/Cuckoo/run generate \\\n    --testable \"$PROJECT_NAME\" \\\n    --output \"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ErrorTranslatorMock.generated.swift\" \\\n    $PROJECT_DIR/$PROJECT_NAME/flux/ErrorTranslator.swift\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -877,6 +881,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0819C96523D806590075B796 /* AlertServiceTest.swift in Sources */,
+				08655AAF23DC181F000E378E /* ErrorTranslatorMock.generated.swift in Sources */,
 				08AB284C23D87BF0005A479B /* XMLParserTests.swift in Sources */,
 				083DAE3F23DBB6C1008F9BC2 /* ModelMocks.generated.swift in Sources */,
 				DBF3AAFE23D932A500D71845 /* TranslateResultViewControllerTests.swift in Sources */,

--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		083DAE3F23DBB6C1008F9BC2 /* ModelMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 083DAE3E23DBB6C1008F9BC2 /* ModelMocks.generated.swift */; };
 		084876CD23DB79E9005302D1 /* PasteBoardModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084876CC23DB79E9005302D1 /* PasteBoardModelTests.swift */; };
 		084876D523DB8680005302D1 /* MenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084876D423DB8680005302D1 /* MenuViewModelTests.swift */; };
+		08655AAD23DC13B1000E378E /* ErrorTranslatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08655AAC23DC13B1000E378E /* ErrorTranslatorTests.swift */; };
 		0869AB9A23DBA8DD00156A52 /* TranslateApiMock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0869AB9923DBA8DC00156A52 /* TranslateApiMock.generated.swift */; };
 		0869AB9C23DBABF100156A52 /* TextInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0869AB9B23DBABF100156A52 /* TextInputViewModelTests.swift */; };
 		08988C7B23D5E27600BAA135 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08988C7A23D5E27600BAA135 /* AppDelegate.swift */; };
@@ -125,6 +126,7 @@
 		08453E9C23DB905D007F773A /* fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fixtures; sourceTree = "<group>"; };
 		084876CC23DB79E9005302D1 /* PasteBoardModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteBoardModelTests.swift; sourceTree = "<group>"; };
 		084876D423DB8680005302D1 /* MenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewModelTests.swift; sourceTree = "<group>"; };
+		08655AAC23DC13B1000E378E /* ErrorTranslatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTranslatorTests.swift; sourceTree = "<group>"; };
 		0869AB9923DBA8DC00156A52 /* TranslateApiMock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranslateApiMock.generated.swift; sourceTree = "<group>"; };
 		0869AB9B23DBABF100156A52 /* TextInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputViewModelTests.swift; sourceTree = "<group>"; };
 		08988C7723D5E27600BAA135 /* HiraganaTranslator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HiraganaTranslator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -368,6 +370,7 @@
 				089A8CD323D88F46000C2F10 /* TestAppDelegate.swift */,
 				0819C96623D8081C0075B796 /* TestUtil.swift */,
 				089A8CF223D8B675000C2F10 /* SnapshotHelper.swift */,
+				08655AAC23DC13B1000E378E /* ErrorTranslatorTests.swift */,
 				0819C96223D806590075B796 /* view */,
 				08AB284A23D87BDC005A479B /* model */,
 				DB4210F023DA772700437AD9 /* generated */,
@@ -886,6 +889,7 @@
 				08258D5923D915990084D51E /* TextInputViewControllerTests.swift in Sources */,
 				089A8CF323D8B675000C2F10 /* SnapshotHelper.swift in Sources */,
 				084876D523DB8680005302D1 /* MenuViewModelTests.swift in Sources */,
+				08655AAD23DC13B1000E378E /* ErrorTranslatorTests.swift in Sources */,
 				08A7D6F623DB9DA90073A85F /* ViewModelMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HiraganaTranslator/flux/ErrorTranslator.swift
+++ b/HiraganaTranslator/flux/ErrorTranslator.swift
@@ -15,7 +15,45 @@ protocol ErrorTranslator {
 class ErrorTranslatorImpl: ErrorTranslator {
     
     func translate(error: Error) -> String {
-        return "Error"
+        if let error = error as? TranslateApiInvalidParamsError {
+            return self.translate(error: error)
+        }
+        else if let error = error as? TranslateApiImpl.CreateRequestFailed {
+            return self.translate(error: error)
+        }
+        else if let error = error as? XMLParseError {
+            return self.translate(error: error)
+        }
+        else if let error = error as? TextRecognizeError {
+            return self.translate(error: error)
+        }
+        else if let error = error as? PasteBoardNoStringError {
+            return self.translate(error: error)
+        }
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return "いんたーねっとに つなげてね"
+        }
+        return "えらーがはっせいしました"
     }
     
+    func translate(error: TranslateApiInvalidParamsError) -> String {
+        return "へんかんしたい ぶんしょうを にゅうりょくしてね"
+    }
+    
+    func translate(error: TranslateApiImpl.CreateRequestFailed) -> String {
+        return "へんかんに しっぱいしました"
+    }
+    
+    func translate(error: XMLParseError) -> String {
+        return "へんかんに しっぱいしました"
+    }
+    
+    func translate(error: TextRecognizeError) -> String {
+        return "じが よめませんでした"
+    }
+    
+    func translate(error: PasteBoardNoStringError) -> String {
+        return "へんかんしたい ぶんしょうを こぴーしてね"
+    }
 }

--- a/HiraganaTranslatorTests/ErrorTranslatorTests.swift
+++ b/HiraganaTranslatorTests/ErrorTranslatorTests.swift
@@ -1,0 +1,51 @@
+//
+//  ErrorTranslatorTests.swift
+//  HiraganaTranslatorTests
+//
+//  Created by Yohta Watanave on 2020/01/25.
+//  Copyright © 2020 Yohta Watanave. All rights reserved.
+//
+
+import XCTest
+@testable import HiraganaTranslator
+
+class ErrorTranslatorTests: XCTestCase {
+
+    func test_TranslateApiInvalidParamsError() {
+        let error = TranslateApiInvalidParamsError()
+        let message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "へんかんしたい ぶんしょうを にゅうりょくしてね")
+    }
+    
+    func test_CreateRequestFailed() {
+        let error = TranslateApiImpl.CreateRequestFailed(cause: nil)
+        let message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "へんかんに しっぱいしました")
+    }
+
+    func test_XMLParseError() {
+        var error = XMLParseError.invalidData
+        var message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "へんかんに しっぱいしました")
+        
+        error = XMLParseError.invalidContent(nodeName: nil)
+        message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "へんかんに しっぱいしました")
+        
+        error = XMLParseError.invalidXML(nodeName: nil)
+        message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "へんかんに しっぱいしました")
+    }
+    
+    func test_TextRecognizeError() {
+        let error = TextRecognizeError.recognizeFaild(cause: nil)
+        let message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "じが よめませんでした")
+    }
+    
+    func test_PasteBoardNoStringError() {
+        let error = PasteBoardNoStringError()
+        let message = ErrorTranslatorImpl().translate(error: error)
+        XCTAssertEqual(message, "へんかんしたい ぶんしょうを こぴーしてね")
+    }
+}

--- a/HiraganaTranslatorTests/TestAppDelegate.swift
+++ b/HiraganaTranslatorTests/TestAppDelegate.swift
@@ -7,13 +7,15 @@
 //
 
 import UIKit
+import Cuckoo
 @testable import HiraganaTranslator
 
 class TestAppDelegate: AppDelegate {
     
     override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UIView.setAnimationsEnabled(false)
-        
+        // For ErrorTranslatorStub
+        DefaultValueRegistry.register(value: "Error", forType: String.self)
         return true
     }
     

--- a/HiraganaTranslatorTests/view/menu/MenuViewControllerTests.swift
+++ b/HiraganaTranslatorTests/view/menu/MenuViewControllerTests.swift
@@ -28,7 +28,7 @@ class MenuViewControllerTests: FBSnapshotTestCase {
         self.testScheduler = TestScheduler(initialClock: 0)
         
         self.viewModel = MockMenuViewModel(
-                errorTranslator: ErrorTranslatorImpl(),
+                errorTranslator: ErrorTranslatorStub(),
                 pasteBoardModel: PasteBoardModelImpl(),
                 textRecognizeModel: MockTextRecognizeModel()
             )

--- a/HiraganaTranslatorTests/view/menu/MenuViewModelTests.swift
+++ b/HiraganaTranslatorTests/view/menu/MenuViewModelTests.swift
@@ -25,7 +25,7 @@ class MenuViewModelTests: XCTestCase {
         self.pasteBoardModel = MockPasteBoardModel()
         self.textRecognizeModel = MockTextRecognizeModel()
         self.viewModel = MenuViewModel(
-            errorTranslator: ErrorTranslatorImpl(),
+            errorTranslator: ErrorTranslatorStub(),
             pasteBoardModel: self.pasteBoardModel,
             textRecognizeModel: self.textRecognizeModel
         )

--- a/HiraganaTranslatorTests/view/textIput/TextInputViewControllerTests.swift
+++ b/HiraganaTranslatorTests/view/textIput/TextInputViewControllerTests.swift
@@ -28,7 +28,7 @@ class TextInputViewControllerTests: FBSnapshotTestCase {
         self.testScheduler = TestScheduler(initialClock: 0)
         
         self.viewModel = MockTextInputViewModel(
-            errorTranslator: ErrorTranslatorImpl(),
+            errorTranslator: ErrorTranslatorStub(),
             translateApi: MockTranslateApi(),
             xmlParseModel: MockXMLParseModel())
         self.viewModel.isStubEnable = true

--- a/HiraganaTranslatorTests/view/textIput/TextInputViewModelTests.swift
+++ b/HiraganaTranslatorTests/view/textIput/TextInputViewModelTests.swift
@@ -26,7 +26,7 @@ class TextInputViewModelTests: XCTestCase {
         self.translateApi = MockTranslateApi()
         self.xmlParseModel = MockXMLParseModel()
         self.viewModel = TextInputViewModel(
-            errorTranslator: ErrorTranslatorImpl(),
+            errorTranslator: ErrorTranslatorStub(),
             translateApi: self.translateApi,
             xmlParseModel: self.xmlParseModel
         )


### PR DESCRIPTION
`flux/Async.swift` に実装されている `bind`メソッドを利用した場合、
onErrorのエラー値を文字列に変換して `Async.fail` としてストリームに流す構造になっています。

XCTestでErrorTranslatorImplを利用していた箇所は、スタブに置き換えました。
これは、機能テストをError文言に依存させないためです。