### PR TITLE
初回ビルドに失敗する

### DIFF
--- a/HiraganaTranslator.xcodeproj/project.pbxproj
+++ b/HiraganaTranslator.xcodeproj/project.pbxproj
@@ -821,8 +821,8 @@
 			);
 			outputPaths = (
 				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ViewModelMocks.generated.swift",
-				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/PasteBoardModelMock.generated.swift",
-				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/TextRecognizeModelMock.generated.swift",
+				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ModelMocks.generated.swift",
+				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/TranslateApiMock.generated.swift",
 				"$PROJECT_DIR/${PROJECT_NAME}Tests/generated/ErrorTranslatorMock.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
モックの自動生成ソースの設定が誤っていたため、初回ビルドに失敗する問題を修正。  
RunScriptsのOutput Filesのパスが誤っていた。