### PR TITLE
共通UIのリファクタリング

### DIFF
--- a/HiraganaTranslator/view/common/RoundTextView.swift
+++ b/HiraganaTranslator/view/common/RoundTextView.swift
@@ -8,15 +8,16 @@
 
 import UIKit
 
+@IBDesignable
 class RoundTextView: UITextView {
 
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
+    override func awakeFromNib() {
+        super.awakeFromNib()
         self.setup()
     }
-
-    override init(frame: CGRect, textContainer: NSTextContainer?) {
-        super.init(frame: frame, textContainer: textContainer)
+    
+    override func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
         self.setup()
     }
     

--- a/HiraganaTranslator/view/common/ThemeButton.swift
+++ b/HiraganaTranslator/view/common/ThemeButton.swift
@@ -22,6 +22,15 @@ class ThemeButton: UIButton {
     }
     
     private func setup() {
+        #if DEBUG
+        print("""
+--------------------------------------------
+Note⚠️: ThemeButton
+This control overrides some properties.
+TitleColor, TintColor, TitleFont, and more.
+These cannot be changed from InterfaceBuilder.
+""")
+        #endif
         let themeColor = UIColor.systemOrange
         let highlightedColor = self.highlightedColor(from: themeColor)
 

--- a/HiraganaTranslator/view/common/ThemeButton.swift
+++ b/HiraganaTranslator/view/common/ThemeButton.swift
@@ -11,22 +11,18 @@ import UIKit
 @IBDesignable
 class ThemeButton: UIButton {
     
-    enum Theme: Int {
-        case `default` = 0
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.setup()
     }
     
-    @IBInspectable
-    var theme: Int = 0 {
-        didSet {
-            switch Theme(rawValue: self.theme) {
-            case .some(.default):
-                self.applyTheme(UIColor.systemOrange)
-            default: break
-            }
-        }
+    override func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+        self.setup()
     }
     
-    private func applyTheme(_ themeColor: UIColor) {
+    private func setup() {
+        let themeColor = UIColor.systemOrange
         let highlightedColor = self.highlightedColor(from: themeColor)
 
         self.setTitleColor(themeColor, for: .normal)

--- a/HiraganaTranslator/view/menu/MenuViewController.xib
+++ b/HiraganaTranslator/view/menu/MenuViewController.xib
@@ -34,31 +34,16 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eeM-7l-elQ" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="158" y="436" width="98" height="24"/>
+                    <rect key="frame" x="127" y="426" width="160" height="44"/>
                     <state key="normal" title="はりつけ" image="Clipboard"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HIa-Gu-AMp" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="149" y="510" width="116" height="24"/>
+                    <rect key="frame" x="113" y="520" width="188" height="44"/>
                     <state key="normal" title="きーぼーど" image="Keyboard"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VIb-Vd-5W2" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="167" y="362" width="80" height="24"/>
+                    <rect key="frame" x="141" y="332" width="132" height="44"/>
                     <state key="normal" title="かめら" image="Camera"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/HiraganaTranslator/view/textInput/TextInputViewController.xib
+++ b/HiraganaTranslator/view/textInput/TextInputViewController.xib
@@ -31,22 +31,12 @@
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="apH-Ks-vVU" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="30" y="260" width="46" height="30"/>
+                    <rect key="frame" x="30" y="260" width="84" height="40"/>
                     <state key="normal" title="もどる"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IkS-ba-ycd" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="228" y="260" width="62" height="30"/>
+                    <rect key="frame" x="178" y="260" width="112" height="40"/>
                     <state key="normal" title="へんかん"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/HiraganaTranslator/view/translateResult/TranslateResultViewController.xib
+++ b/HiraganaTranslator/view/translateResult/TranslateResultViewController.xib
@@ -47,22 +47,12 @@
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ghB-Ia-xLI" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="106" y="468" width="108" height="30"/>
+                    <rect key="frame" x="62" y="448" width="196" height="40"/>
                     <state key="normal" title="はじめにもどる"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O2D-5j-qXM" customClass="ThemeButton" customModule="HiraganaTranslator" customModuleProvider="target">
-                    <rect key="frame" x="91" y="518" width="138" height="30"/>
+                    <rect key="frame" x="34" y="508" width="252" height="40"/>
                     <state key="normal" title="ぶんしょうをなおす"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="number" keyPath="theme">
-                            <integer key="value" value="0"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="もとのぶんしょう" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O5h-gp-7vn">
                     <rect key="frame" x="100" y="235" width="120" height="15"/>


### PR DESCRIPTION
## ThemeButton
InterfaceBuilderで外観チェックするためにIBDesignableとIBInspectionを採用していました。
が、IBInspectionの値は固定値で無意味でした。
そのため、IBInspectionを廃止し、 `prepareForInterfaceBuilder` をoverrideすることで対応しました。

また、現状このクラスはInterfaceBuilderで設定してもフォントやTintColorは適用されないので複数人でのメンテナンスには向きません。なので一応、その旨をログに出力しました。
もし、複数人でのメンテナンスを前提とするなら他の手法を取る方が良いと思っています。
(appearance proxyで解決出来ればよかったのですが...)

## RoundTextView
こちらは新たにIBDesignableを採用することにしました。